### PR TITLE
Add Docker support for easy deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# Git
+.git
+.gitignore
+
+# Documentation
+README.md
+LICENSE
+*.md
+example-use.png
+
+# Development files
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Go files (for bridge)
+whatsapp-bridge/whatsapp-bridge
+whatsapp-bridge/*.db
+whatsapp-bridge/*.log
+
+# Python files (for MCP server)
+whatsapp-mcp-server/__pycache__
+whatsapp-mcp-server/*.pyc
+whatsapp-mcp-server/*.pyo
+whatsapp-mcp-server/*.pyd
+whatsapp-mcp-server/.Python
+whatsapp-mcp-server/.uv
+whatsapp-mcp-server/.venv
+whatsapp-mcp-server/venv
+
+# Docker files
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Temporary files
+*.tmp
+*.temp
+*.bak

--- a/README.md
+++ b/README.md
@@ -10,121 +10,246 @@ Here's an example of what you can do when it's connected to Claude.
 
 ![WhatsApp MCP](./example-use.png)
 
-> To get updates on this and other projects I work on [enter your email here](https://docs.google.com/forms/d/1rTF9wMBTN0vPfzWuQa2BjfGKdKIpTbyeKxhPMcEzgyI/preview)
+> _Caution:_ as with many MCP servers, the WhatsApp MCP is subject to [the lethal trifecta](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/). This means that project injection could lead to private data exfiltration.
 
-> *Caution:* as with many MCP servers, the WhatsApp MCP is subject to [the lethal trifecta](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/). This means that project injection could lead to private data exfiltration.
+## Quick Start
+
+The easiest way to get started is using Docker:
+
+```bash
+# Clone the repository
+git clone https://github.com/voska/whatsapp-mcp.git
+cd whatsapp-mcp
+
+# Build and start the WhatsApp bridge
+docker-compose up
+
+# When you see the QR code, scan it with WhatsApp on your phone
+# Then configure Claude Desktop (see below)
+```
 
 ## Installation
 
 ### Prerequisites
 
-- Go
-- Python 3.6+
+For Docker setup (recommended):
+
+- Docker and Docker Compose installed
 - Anthropic Claude Desktop app (or Cursor)
-- UV (Python package manager), install with `curl -LsSf https://astral.sh/uv/install.sh | sh`
 - FFmpeg (_optional_) - Only needed for audio messages. If you want to send audio files as playable WhatsApp voice messages, they must be in `.ogg` Opus format. With FFmpeg installed, the MCP server will automatically convert non-Opus audio files. Without FFmpeg, you can still send raw audio files using the `send_file` tool.
 
-### Steps
+For manual setup:
 
-1. **Clone this repository**
+- Go 1.19+
+- Python 3.6+ with UV package manager
+- FFmpeg (_optional_) - Same as above
+
+### Setup
+
+#### Option 1: Docker (Recommended)
+
+1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/lharries/whatsapp-mcp.git
+   git clone https://github.com/voska/whatsapp-mcp.git
    cd whatsapp-mcp
    ```
 
-2. **Run the WhatsApp bridge**
+2. **Build the Docker images**
 
-   Navigate to the whatsapp-bridge directory and run the Go application:
+   ```bash
+   docker-compose build
+   ```
+
+3. **Start the WhatsApp bridge**
+
+   ```bash
+   docker-compose up
+   ```
+
+4. **Authenticate with WhatsApp**
+
+   - When you first run it, you'll see a QR code in the terminal
+   - Scan this QR code with WhatsApp on your phone (see [QR Code Authentication](#qr-code-authentication))
+
+5. **Configure Claude Desktop** - Follow the [MCP Configuration](#mcp-configuration) section below
+
+#### Option 2: Manual Setup
+
+1. **Clone the repository**
+
+   ```bash
+   git clone https://github.com/voska/whatsapp-mcp.git
+   cd whatsapp-mcp
+   ```
+
+2. **Install UV** (Python package manager)
+
+   ```bash
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+
+3. **Run the WhatsApp bridge**
 
    ```bash
    cd whatsapp-bridge
    go run main.go
    ```
 
-   The first time you run it, you will be prompted to scan a QR code. Scan the QR code with your WhatsApp mobile app to authenticate.
+   Scan the QR code when it appears.
 
-   After approximately 20 days, you will might need to re-authenticate.
+4. **Configure Claude Desktop** with manual setup instructions
 
-3. **Connect to the MCP server**
+### QR Code Authentication
 
-   Copy the below json with the appropriate {{PATH}} values:
+When you first run the WhatsApp bridge, you'll need to link it to your WhatsApp account:
 
-   ```json
-   {
-     "mcpServers": {
-       "whatsapp": {
-         "command": "{{PATH_TO_UV}}", // Run `which uv` and place the output here
-         "args": [
-           "--directory",
-           "{{PATH_TO_SRC}}/whatsapp-mcp/whatsapp-mcp-server", // cd into the repo, run `pwd` and enter the output here + "/whatsapp-mcp-server"
-           "run",
-           "main.py"
-         ]
-       }
-     }
-   }
-   ```
+1. **Open WhatsApp on your phone**
+2. **Go to Settings** (tap ⋮ on Android or Settings tab on iPhone)
+3. **Select "Linked Devices"**
+4. **Tap "Link a Device"**
+5. **Scan the QR code** displayed in your terminal
 
-   For **Claude**, save this as `claude_desktop_config.json` in your Claude Desktop configuration directory at:
+The QR code looks like this in the terminal:
 
-   ```
-   ~/Library/Application Support/Claude/claude_desktop_config.json
-   ```
+```
+████████████████████████████████████████████
+████ ▄▄▄▄▄ █▀█ █▄█▀█▀▄█ ▀▄▀▄▀ █ ▄▄▄▄▄ ████
+████ █   █ █▀▀▀█ ▀▄█▀▀▀▀█▀ ▄ ▀█ █   █ ████
+████ █▄▄▄█ █▀ █▀▀██▀▄▀ ▀█ ██▀▄█ █▄▄▄█ ████
+... (more lines)
+```
 
-   For **Cursor**, save this as `mcp.json` in your Cursor configuration directory at:
+**Important Notes:**
 
-   ```
-   ~/.cursor/mcp.json
-   ```
+- The QR code only appears on first run or after authentication expires (~20 days)
+- If already authenticated, the bridge will connect automatically
+- Keep the bridge running to maintain the WhatsApp connection
 
-4. **Restart Claude Desktop / Cursor**
+### MCP Configuration
 
-   Open Claude Desktop and you should now see WhatsApp as an available integration.
+Configure Claude Desktop or Cursor to use the MCP server:
 
-   Or restart Cursor.
+#### For Docker Users
 
-### Windows Compatibility
+Copy this configuration and save it:
 
-If you're running this project on Windows, be aware that `go-sqlite3` requires **CGO to be enabled** in order to compile and work properly. By default, **CGO is disabled on Windows**, so you need to explicitly enable it and have a C compiler installed.
+```json
+{
+  "mcpServers": {
+    "whatsapp": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-v",
+        "{{PATH_TO_PROJECT}}/whatsapp-bridge/messages.db:/app/messages.db:ro",
+        "walla-walla-mcp-server"
+      ]
+    }
+  }
+}
+```
 
-#### Steps to get it working:
+Replace `{{PATH_TO_PROJECT}}` with the full path to your whatsapp-mcp directory (run `pwd` in the project directory).
 
-1. **Install a C compiler**  
-   We recommend using [MSYS2](https://www.msys2.org/) to install a C compiler for Windows. After installing MSYS2, make sure to add the `ucrt64\bin` folder to your `PATH`.  
-   → A step-by-step guide is available [here](https://code.visualstudio.com/docs/cpp/config-mingw).
+#### For Manual Setup Users
 
-2. **Enable CGO and run the app**
+```json
+{
+  "mcpServers": {
+    "whatsapp": {
+      "command": "{{PATH_TO_UV}}",
+      "args": [
+        "--directory",
+        "{{PATH_TO_PROJECT}}/whatsapp-mcp-server",
+        "run",
+        "main.py"
+      ]
+    }
+  }
+}
+```
+
+Replace:
+
+- `{{PATH_TO_UV}}` with the output of `which uv`
+- `{{PATH_TO_PROJECT}}` with the full path to your whatsapp-mcp directory
+
+#### Save Configuration
+
+**For Claude Desktop:**
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+**For Cursor:**
+
+- `~/.cursor/mcp.json`
+
+After saving, restart Claude Desktop or Cursor.
+
+## Docker Commands
+
+### Basic Operations
+
+```bash
+# Start the bridge
+docker-compose up -d
+
+# View logs (and QR code)
+docker-compose logs -f
+
+# Stop the bridge
+docker-compose down
+
+# Rebuild after updates
+docker-compose build
+docker-compose up -d
+
+# Reset everything (deletes all data)
+docker-compose down -v
+```
+
+### Data Persistence
+
+- WhatsApp session: Stored in `whatsapp-data` Docker volume
+- Message history: Stored in `whatsapp-bridge/messages.db`
+
+To backup your data:
+
+```bash
+# Backup messages
+cp whatsapp-bridge/messages.db messages-backup.db
+
+# Backup WhatsApp session
+docker run --rm -v walla-walla_whatsapp-data:/data -v $(pwd):/backup alpine tar czf /backup/whatsapp-backup.tar.gz -C /data .
+```
+
+## Verifying Your Setup
+
+1. **Check bridge status**
 
    ```bash
-   cd whatsapp-bridge
-   go env -w CGO_ENABLED=1
-   go run main.go
+   docker-compose ps  # Should show "Up" status
    ```
 
-Without this setup, you'll likely run into errors like:
-
-> `Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work.`
-
-## Architecture Overview
-
-This application consists of two main components:
-
-1. **Go WhatsApp Bridge** (`whatsapp-bridge/`): A Go application that connects to WhatsApp's web API, handles authentication via QR code, and stores message history in SQLite. It serves as the bridge between WhatsApp and the MCP server.
-
-2. **Python MCP Server** (`whatsapp-mcp-server/`): A Python server implementing the Model Context Protocol (MCP), which provides standardized tools for Claude to interact with WhatsApp data and send/receive messages.
-
-### Data Storage
-
-- All message history is stored in a SQLite database within the `whatsapp-bridge/store/` directory
-- The database maintains tables for chats and messages
-- Messages are indexed for efficient searching and retrieval
+2. **In Claude Desktop**
+   - Look for the 🔌 icon and check if WhatsApp appears
+   - Try: "Can you list my recent WhatsApp chats?"
 
 ## Usage
 
-Once connected, you can interact with your WhatsApp contacts through Claude, leveraging Claude's AI capabilities in your WhatsApp conversations.
+Once connected, Claude can help you:
 
-### MCP Tools
+- Search and read WhatsApp messages
+- Send messages to contacts and groups
+- Share files, images, videos, and voice messages
+- Download media from conversations
+- Search contacts by name or phone number
+
+### Available Tools
 
 Claude can access the following tools to interact with WhatsApp:
 
@@ -157,9 +282,23 @@ You can send various media types to your WhatsApp contacts:
 
 #### Media Downloading
 
-By default, just the metadata of the media is stored in the local database. The message will indicate that media was sent. To access this media you need to use the download_media tool which takes the `message_id` and `chat_jid` (which are shown when printing messages containing the meda), this downloads the media and then returns the file path which can be then opened or passed to another tool.
+By default, just the metadata of the media is stored in the local database. The message will indicate that media was sent. To access this media you need to use the download_media tool which takes the `message_id` and `chat_jid` (which are shown when printing messages containing the media), this downloads the media and then returns the file path which can be then opened or passed to another tool.
 
-## Technical Details
+## Architecture Overview
+
+This application consists of two main components:
+
+1. **Go WhatsApp Bridge** (`whatsapp-bridge/`): A Go application that connects to WhatsApp's web API, handles authentication via QR code, and stores message history in SQLite. It serves as the bridge between WhatsApp and the MCP server.
+
+2. **Python MCP Server** (`whatsapp-mcp-server/`): A Python server implementing the Model Context Protocol (MCP), which provides standardized tools for Claude to interact with WhatsApp data and send/receive messages.
+
+### Data Storage
+
+- All message history is stored in a SQLite database within the `whatsapp-bridge/store/` directory
+- The database maintains tables for chats and messages
+- Messages are indexed for efficient searching and retrieval
+
+### Technical Details
 
 1. Claude sends requests to the Python MCP server
 2. The MCP server queries the Go bridge for WhatsApp data or directly to the SQLite database
@@ -169,15 +308,77 @@ By default, just the metadata of the media is stored in the local database. The 
 
 ## Troubleshooting
 
-- If you encounter permission issues when running uv, you may need to add it to your PATH or use the full path to the executable.
-- Make sure both the Go application and the Python server are running for the integration to work properly.
+### QR Code Issues
 
-### Authentication Issues
+**Can't see the QR code:**
 
-- **QR Code Not Displaying**: If the QR code doesn't appear, try restarting the authentication script. If issues persist, check if your terminal supports displaying QR codes.
-- **WhatsApp Already Logged In**: If your session is already active, the Go bridge will automatically reconnect without showing a QR code.
-- **Device Limit Reached**: WhatsApp limits the number of linked devices. If you reach this limit, you'll need to remove an existing device from WhatsApp on your phone (Settings > Linked Devices).
-- **No Messages Loading**: After initial authentication, it can take several minutes for your message history to load, especially if you have many chats.
-- **WhatsApp Out of Sync**: If your WhatsApp messages get out of sync with the bridge, delete both database files (`whatsapp-bridge/store/messages.db` and `whatsapp-bridge/store/whatsapp.db`) and restart the bridge to re-authenticate.
+- Use `docker-compose logs -f` to view it
+- Make sure your terminal window is wide enough
+- Try `docker-compose restart` if it doesn't appear
 
-For additional Claude Desktop integration troubleshooting, see the [MCP documentation](https://modelcontextprotocol.io/quickstart/server#claude-for-desktop-integration-issues). The documentation includes helpful tips for checking logs and resolving common issues.
+**Authentication expired:**
+
+- Simply restart the bridge to get a new QR code
+- Scan it again with WhatsApp
+
+### Connection Problems
+
+**Bridge won't start:**
+
+```bash
+# Check if port 8080 is already in use
+lsof -i :8080
+
+# View detailed logs
+docker-compose logs --tail=50
+```
+
+**MCP can't connect:**
+
+- Ensure bridge is running: `docker-compose ps`
+- Check your claude_desktop_config.json path is correct
+- Try restarting Claude Desktop
+
+### Data Issues
+
+**Messages out of sync:**
+
+```bash
+# Reset and re-authenticate
+docker-compose down -v
+rm whatsapp-bridge/messages.db
+docker-compose up
+```
+
+### Windows-Specific Issues
+
+For manual setup on Windows, `go-sqlite3` requires CGO:
+
+1. Install [MSYS2](https://www.msys2.org/) and add to PATH
+2. Enable CGO:
+   ```bash
+   go env -w CGO_ENABLED=1
+   go run main.go
+   ```
+
+## Security Notes
+
+- All data is stored locally
+- Messages are only sent to Claude when you explicitly use WhatsApp tools
+- The bridge requires continuous connection to maintain authentication
+- Consider the [security implications](https://simonwillison.net/2025/Jun/16/the-lethal-trifecta/) of MCP servers
+
+## Support
+
+- Check logs: `docker-compose logs`
+- File issues: [GitHub Issues](https://github.com/voska/whatsapp-mcp/issues)
+- MCP docs: [Model Context Protocol](https://modelcontextprotocol.io)
+
+## Credits
+
+This project is a fork of the original [whatsapp-mcp](https://github.com/lharries/whatsapp-mcp) by [lharries](https://github.com/lharries). 
+
+Major contributions in this fork:
+- Fixed WebSocket connection issues by updating whatsmeow dependency
+- Added Docker support for easy deployment
+- Simplified setup process with Docker Compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  whatsapp-bridge:
+    build:
+      context: ./whatsapp-bridge
+      dockerfile: Dockerfile
+    container_name: whatsapp-bridge
+    ports:
+      - "8080:8080"
+    volumes:
+      - whatsapp-data:/app/data
+      - ./whatsapp-bridge/messages.db:/app/messages.db
+    environment:
+      - DB_PATH=/app/data/whatsmeow.db
+      - MESSAGES_DB_PATH=/app/messages.db
+    restart: unless-stopped
+
+volumes:
+  whatsapp-data:

--- a/whatsapp-bridge/Dockerfile
+++ b/whatsapp-bridge/Dockerfile
@@ -1,0 +1,39 @@
+# Build stage
+FROM golang:1.24.1-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache gcc musl-dev sqlite-dev
+
+WORKDIR /app
+
+# Copy go mod files
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy source code
+COPY main.go ./
+
+# Build the application
+RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -o whatsapp-bridge main.go
+
+# Runtime stage
+FROM alpine:latest
+
+# Install runtime dependencies
+RUN apk add --no-cache ca-certificates sqlite-libs
+
+WORKDIR /app
+
+# Copy the binary from builder
+COPY --from=builder /app/whatsapp-bridge .
+
+# Create directory for database
+RUN mkdir -p /app/data
+
+# Expose the HTTP port
+EXPOSE 8080
+
+# Run the application
+CMD ["./whatsapp-bridge"]

--- a/whatsapp-mcp-server/Dockerfile
+++ b/whatsapp-mcp-server/Dockerfile
@@ -1,0 +1,19 @@
+# Use Python 3.11 slim image
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install uv for dependency management
+RUN pip install uv
+
+# Copy dependency files
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies using uv
+RUN uv sync --frozen
+
+# Copy application files
+COPY *.py ./
+
+# Run the MCP server
+CMD ["uv", "run", "python", "main.py"]

--- a/whatsapp-mcp-server/whatsapp.py
+++ b/whatsapp-mcp-server/whatsapp.py
@@ -3,12 +3,13 @@ from datetime import datetime
 from dataclasses import dataclass
 from typing import Optional, List, Tuple
 import os.path
+import os
 import requests
 import json
 import audio
 
-MESSAGES_DB_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'whatsapp-bridge', 'store', 'messages.db')
-WHATSAPP_API_BASE_URL = "http://localhost:8080/api"
+MESSAGES_DB_PATH = os.getenv("MESSAGES_DB_PATH", os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'whatsapp-bridge', 'store', 'messages.db'))
+WHATSAPP_API_BASE_URL = os.getenv("WHATSAPP_API_BASE_URL", "http://localhost:8080") + "/api"
 
 @dataclass
 class Message:


### PR DESCRIPTION
## Summary
- Added complete Docker support for both WhatsApp bridge and MCP server
- Simplified setup process to just `docker-compose up`
- Users no longer need to install Go, Python, or UV separately

## Changes Made
- **Added Dockerfiles**: Multi-stage Go build for bridge, Python 3.11 for MCP server
- **Created docker-compose.yml**: Orchestrates both services (bridge only, MCP runs via stdio)
- **Updated whatsapp.py**: Now uses environment variables for configuration
- **Simplified README**: Docker is now the primary installation method with clear QR code instructions
- **Updated repository references**: Changed from lharries to voska
- **Added credits section**: Acknowledges original author

## Test Plan
- [x] Built both Docker images successfully
- [x] Tested WhatsApp bridge startup and QR code display
- [x] Verified environment variable configuration works
- [x] Confirmed MCP server can be run with Docker
- [x] Updated all documentation

## Benefits
1. **Easier setup**: Single command to get started
2. **No dependencies**: Users only need Docker installed
3. **Consistent environment**: Works the same on all platforms
4. **Better isolation**: Services run in containers

🤖 Generated with Claude Code